### PR TITLE
Misc Cleanup of the CRIU demo

### DIFF
--- a/Dockerfiles/Dockerfile.checkpoint
+++ b/Dockerfiles/Dockerfile.checkpoint
@@ -20,14 +20,11 @@ USER root
 #create the chekpoint
 RUN cd /instantOnDemo \
  && sed -i 's/\/\/checkPointJVM("checkpointData");/checkPointJVM("checkpointData");/g' HelloInstantOn.java \
- && javac HelloInstantOn.java \
- && mkdir checkpointData
+ && javac HelloInstantOn.java
 
 WORKDIR /instantOnDemo
 
 USER root
 
-#ENTRYPOINT ["/usr/bin/dumb-init", "--"]
-CMD ["/usr/bin/dumb-init", "--", "java", "-XX:+EnableCRIUSupport", "HelloInstantOn"]
-#CMD ["criu", "restore", "-D", "./checkpointData", "--shell-job"]
-#CMD ["bash", "restore.sh"]
+ENTRYPOINT ["./Scripts/entry-point.sh"]
+

--- a/Dockerfiles/Dockerfile.ubuntu20
+++ b/Dockerfiles/Dockerfile.ubuntu20
@@ -102,16 +102,16 @@ RUN apt-get update \
 RUN cd /tmp \
  && wget --progress=dot:mega -O criu.tar.gz https://github.com/checkpoint-restore/criu/archive/refs/tags/v3.17.1.tar.gz \
  && tar -xzf criu.tar.gz \
- && mv criu-3.16.1 criu-build \
+ && mv criu-3.17.1 criu-build \
  && cd criu-build \
  && make \
- && make DESTDIR=/tmp/criu-3.16.1 install-lib install-criu \
+ && make DESTDIR=/tmp/criu-3.17.1 install-lib install-criu \
  && cd .. \
  && rm -fr criu.tar.gz criu-build
 
 # Install CRIU.
 FROM base
-COPY --from=criu-builder /tmp/criu-3.16.1/usr/local /usr/local
+COPY --from=criu-builder /tmp/criu-3.17.1/usr/local /usr/local
 # Set CRIU capabilities.
 RUN setcap cap_chown,cap_dac_override,cap_dac_read_search,cap_fowner,cap_fsetid,cap_kill,cap_setgid,cap_setuid,cap_setpcap,cap_net_admin,cap_sys_chroot,cap_sys_ptrace,cap_sys_admin,cap_sys_resource,cap_sys_time,cap_audit_control=eip /usr/local/sbin/criu
 
@@ -122,6 +122,7 @@ RUN for dir in lib lib64 lib/x86_64-linux-gnu ; do echo /usr/local/$dir ; done >
 # Get Semeru InstantOn
 RUN cd / \
  && mkdir /instantOnDemo \
+ && chown -R 1001:0 /instantOnDemo \
  && cd instantOnDemo \
  && wget --progress=dot:mega -O semeruInstantOn.tar.gz https://github.com/ibmruntimes/semeru17-ea-binaries/releases/download/jdk-17.0.5%2B2_august_22-preview_3/ibm-semeru-open-ea-jdk_x64_linux_17.0.5_2_august_22-preview_3.tar.gz \
  && tar -xzf semeruInstantOn.tar.gz \
@@ -129,10 +130,10 @@ RUN cd / \
  && rm -rf semeruInstantOn.tar.gz
 
 ENV JAVA_HOME=/instantOnDemo/semeruInstantOn
-ENV PATH=$JAVA_HOME/bin:$PATH
+ENV PATH=$JAVA_HOME/bin:/instantOnDemo:$PATH
 
 WORKDIR /instantOnDemo
 
-COPY --chown=1001:0 Scripts/restore.sh /instantOnDemo/restore.sh
-COPY --chown=1001:0 Scripts/checkpoint.sh /instantOnDemo/checkpoint.sh
+COPY --chown=1001:0 Scripts /instantOnDemo/Scripts
 COPY --chown=1001:0 Samples/HelloInstantOn.java /instantOnDemo/HelloInstantOn.java
+RUN chmod a+rx /instantOnDemo/Scripts/*

--- a/Scripts/checkpoint.sh
+++ b/Scripts/checkpoint.sh
@@ -16,6 +16,13 @@
 # limitations under the License.
 ###############################################################################
 
+# hack to bump up the pid by 100
+for i in {1..100}
+do
+    ./Scripts/pidplus.sh
+done
+
+mkdir checkpointData
 java -XX:+EnableCRIUSupport HelloInstantOn
 
 exit 0

--- a/Scripts/entry-point.sh
+++ b/Scripts/entry-point.sh
@@ -16,9 +16,10 @@
 # limitations under the License.
 ###############################################################################
 
-docker build -f Dockerfiles/Dockerfile.ubuntu20 -t instantondemo:ub20 .
-docker build -f Dockerfiles/Dockerfile.checkpoint -t instantoncheckpoint:ub20 .
-docker run --name checkpointrun --cap-add=ALL --privileged -it instantoncheckpoint:ub20
-docker wait checkpointrun
-docker commit checkpointrun restorerun
-docker rm checkpointrun
+if [ -d "./checkpointData" ]; then
+  exec dumb-init --rewrite 15:2 -- "./Scripts/restore.sh"
+else
+  ./Scripts/checkpoint.sh
+fi
+
+

--- a/Scripts/pidplus.sh
+++ b/Scripts/pidplus.sh
@@ -16,9 +16,5 @@
 # limitations under the License.
 ###############################################################################
 
-docker build -f Dockerfiles/Dockerfile.ubuntu20 -t instantondemo:ub20 .
-docker build -f Dockerfiles/Dockerfile.checkpoint -t instantoncheckpoint:ub20 .
-docker run --name checkpointrun --cap-add=ALL --privileged -it instantoncheckpoint:ub20
-docker wait checkpointrun
-docker commit checkpointrun restorerun
-docker rm checkpointrun
+# hack to bump up the pid 
+echo "nothing" > /dev/null

--- a/Scripts/restoreContainer.sh
+++ b/Scripts/restoreContainer.sh
@@ -16,4 +16,4 @@
 # limitations under the License.
 ###############################################################################
 
-docker run --rm --cap-add=ALL --privileged -it restorerun criu restore -D ./checkpointData --shell-job -v4 --log-file=restore.log
+docker run --rm --cap-add=ALL --privileged -it restorerun 


### PR DESCRIPTION
* Added `entry-point.sh` that automatically calls the checkpoint or restore script depending on if the imageDir exists
* Added `pidplus.sh` to increment the last PID to prevent PID clashes during restore
* Fixed `Dockerfile.ubuntu20` to use the correct CRIU dir after extract v3.17.1
* Fixed `restoreContainer.sh` to no longer have to pass in the CMD to run